### PR TITLE
Update lifecycle Hooks

### DIFF
--- a/index.js
+++ b/index.js
@@ -64,16 +64,22 @@ class Crypt {
     };
 
     this.hooks = {
-      'before:deploy:function:deploy': () => BbPromise.bind(this)
+      'before:deploy:function:packageFunction': () => BbPromise.bind(this)
         .then(this.validate)
         .then(this.addLibraries),
-      'after:deploy:function:deploy': () => BbPromise.bind(this)
+      'after:deploy:function:packageFunction': () => BbPromise.bind(this)
         .then(this.validate)
         .then(this.removeLibraries),
-      'before:deploy:createDeploymentArtifacts': () => BbPromise.bind(this)
+      'before:package:createDeploymentArtifacts': () => BbPromise.bind(this)
         .then(this.validate)
         .then(this.addLibraries),
-      'after:deploy:deploy': () => BbPromise.bind(this)
+      'after:package:createDeploymentArtifacts': () => BbPromise.bind(this)
+        .then(this.validate)
+        .then(this.removeLibraries),
+      'before:invoke:local:invoke': () => BbPromise.bind(this)
+        .then(this.validate)
+        .then(this.addLibraries),
+      'after:invoke:local:invoke': () => BbPromise.bind(this)
         .then(this.validate)
         .then(this.removeLibraries),
       'encrypt:encrypt': () => BbPromise.bind(this)

--- a/test/index.js
+++ b/test/index.js
@@ -57,13 +57,13 @@ describe('Crypt', () => {
     //   expect(cryptWithEmptyOptions.options).to.deep.equal({});
     // });
 
-    it('should run promise chain in order for before:deploy:function:deploy', () => {
+    it('should run promise chain in order for before:deploy:function:packageFunction', () => {
       const validateStub = sinon
         .stub(crypt, 'validate').returns(BbPromise.resolve());
       const addLibrariesStub = sinon
         .stub(crypt, 'addLibraries').returns(BbPromise.resolve());
 
-      return crypt.hooks['before:deploy:function:deploy']().then(() => {
+      return crypt.hooks['before:deploy:function:packageFunction']().then(() => {
         expect(validateStub.calledOnce).to.equal(true);
         expect(addLibrariesStub.calledAfter(validateStub))
           .to.equal(true);
@@ -73,13 +73,13 @@ describe('Crypt', () => {
       });
     });
 
-    it('should run promise chain in order for after:deploy:function:deploy', () => {
+    it('should run promise chain in order for after:deploy:function:packageFunction', () => {
       const validateStub = sinon
         .stub(crypt, 'validate').returns(BbPromise.resolve());
       const removeLibrariesStub = sinon
         .stub(crypt, 'removeLibraries').returns(BbPromise.resolve());
 
-      return crypt.hooks['after:deploy:function:deploy']().then(() => {
+      return crypt.hooks['after:deploy:function:packageFunction']().then(() => {
         expect(validateStub.calledOnce).to.equal(true);
         expect(removeLibrariesStub.calledAfter(validateStub))
           .to.equal(true);
@@ -89,13 +89,13 @@ describe('Crypt', () => {
       });
     });
 
-    it('should run promise chain in order for before:deploy:createDeploymentArtifacts', () => {
+    it('should run promise chain in order for before:package:createDeploymentArtifacts', () => {
       const validateStub = sinon
         .stub(crypt, 'validate').returns(BbPromise.resolve());
       const addLibrariesStub = sinon
         .stub(crypt, 'addLibraries').returns(BbPromise.resolve());
 
-      return crypt.hooks['before:deploy:createDeploymentArtifacts']().then(() => {
+      return crypt.hooks['before:package:createDeploymentArtifacts']().then(() => {
         expect(validateStub.calledOnce).to.equal(true);
         expect(addLibrariesStub.calledAfter(validateStub))
           .to.equal(true);
@@ -105,13 +105,13 @@ describe('Crypt', () => {
       });
     });
 
-    it('should run promise chain in order for after:deploy:deploy', () => {
+    it('should run promise chain in order for after:package:createDeploymentArtifacts', () => {
       const validateStub = sinon
         .stub(crypt, 'validate').returns(BbPromise.resolve());
       const removeLibrariesStub = sinon
         .stub(crypt, 'removeLibraries').returns(BbPromise.resolve());
 
-      return crypt.hooks['after:deploy:deploy']().then(() => {
+      return crypt.hooks['after:package:createDeploymentArtifacts']().then(() => {
         expect(validateStub.calledOnce).to.equal(true);
         expect(removeLibrariesStub.calledAfter(validateStub))
           .to.equal(true);

--- a/test/index.js
+++ b/test/index.js
@@ -121,6 +121,38 @@ describe('Crypt', () => {
       });
     });
 
+    it('should run promise chain in order for before:invoke:local:invoke', () => {
+      const validateStub = sinon
+        .stub(crypt, 'validate').returns(BbPromise.resolve());
+      const addLibrariesStub = sinon
+        .stub(crypt, 'addLibraries').returns(BbPromise.resolve());
+
+      return crypt.hooks['before:invoke:local:invoke']().then(() => {
+        expect(validateStub.calledOnce).to.equal(true);
+        expect(addLibrariesStub.calledAfter(validateStub))
+          .to.equal(true);
+
+        crypt.validate.restore();
+        crypt.addLibraries.restore();
+      });
+    });
+
+    it('should run promise chain in order for after:invoke:local:invoke', () => {
+      const validateStub = sinon
+        .stub(crypt, 'validate').returns(BbPromise.resolve());
+      const removeLibrariesStub = sinon
+        .stub(crypt, 'removeLibraries').returns(BbPromise.resolve());
+
+      return crypt.hooks['after:invoke:local:invoke']().then(() => {
+        expect(validateStub.calledOnce).to.equal(true);
+        expect(removeLibrariesStub.calledAfter(validateStub))
+          .to.equal(true);
+
+        crypt.validate.restore();
+        crypt.removeLibraries.restore();
+      });
+    });
+
     it('should run promise chain in order for encrypt:encrypt', () => {
       const validateStub = sinon
         .stub(crypt, 'validate').returns(BbPromise.resolve());


### PR DESCRIPTION
Using `package` hook instead of deprecated deploy hooks and added to invoke local hooks